### PR TITLE
Fix: Cart-icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,7 +41,12 @@
     <section class="cart-container">
       <!-- Cart icon -->
       <button id="cart-open-button" class="cart-open-button">
-        <img src="images/icons8-cart-48.png" alt="Kundvagnsikon">
+        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" 
+        class="feather feather-shopping-cart">
+        <circle cx="9" cy="21" r="1.3"></circle>
+        <circle cx="20" cy="21" r="1.3"></circle>
+        <path d="M1 1h4l2.68 13.39a2 2 0 0 0 2 1.61h9.72a2 2 0 0 0 2-1.61L23 6H6"></path>
+      </svg>
         <span id="cart-count" class="cart-count">0</span>
       </button>
       <!-- Cart popup -->

--- a/styles/style.css
+++ b/styles/style.css
@@ -85,15 +85,21 @@ main section#section_snacks {
   box-shadow: rgba(99, 99, 99, 0.2) 0px 4px 12px 0px;
   background-color: black;
   cursor: pointer;
+  border: none;
 }
 
 .cart-open-button:hover {
   transform: scale(1.1); /* Increases the size when hover */
 }
 
-.cart-open-button img {
+.cart-open-button svg {
   width: 35px; 
   height: 35px; 
+  fill: none;
+  stroke: white;
+  stroke-width: 1;
+  stroke-linecap: round;
+  stroke-linejoin: round;
 }
 
 .cart-count {


### PR DESCRIPTION
Har bytt från **png** till **svg**:
-  Kan nu skalas upp och ner i storlek utan kvalitetsförlust.
-  Kan styleas med css och js _(te.x storlek, färg, animering vid hovring)_.

Jag tror att svg stödjs av de flesta plattformarna så bör inte vara några problem, men ska kika mer på det. 