### PR TITLE
Responsivness sections

### DIFF
--- a/styles/style.css
+++ b/styles/style.css
@@ -74,7 +74,7 @@ body {
 main {
   width: 100%;
   margin: 0 auto;
-  min-height: calc(100vh - 38px);
+  min-height: calc(100vh - 42px);
   padding-top: 80px; /* Pushes the content below the header*/
 }
 
@@ -315,12 +315,15 @@ main {
 
 .site-footer p {
   width: 100%;
-  height: 38px;
-  font-size: 16px;
+  height: 42px;
+  font-size: 15px;
   padding: 10px;
   text-align: center;
   background-color: #101010;
   color: rgb(241, 239, 239);
   z-index: 2; /* To keep the footer in front of the cart popup-slide */
   position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -128,6 +128,9 @@ main {
   background-color: #e0f7fa;
   border-radius: 10px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 #section_drinks h2 {
@@ -135,12 +138,13 @@ main {
   font-size: 24px;
   color: black;
   margin-bottom: 20px;
+  width: 100%;
 }
 
 .dryck {
   display: inline-block;
   text-align: center;
-  width: 200px;
+  max-width: 200px;
   margin: 10px;
   padding: 15px;
   background-color: white;
@@ -148,6 +152,7 @@ main {
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s, box-shadow 0.2s;
+  flex: 1 1 150px;
 }
 
 .dryck:hover {
@@ -181,6 +186,9 @@ main {
   background-color: #fff3e0;
   border-radius: 10px;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
 }
 
 #section_snacks h2 {
@@ -188,18 +196,20 @@ main {
   font-size: 24px;
   color: black;
   margin-bottom: 20px;
+  width: 100%;
 }
 
 .snacks {
   display: inline-block;
   text-align: center;
-  width: 200px;
+  max-width: 200px;
   margin: 10px;
   padding: 15px;
   background-color: #ffffff;
   border: 1px solid #b2dfdb;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s, box-shadow 0.2s;
+  flex: 1 1 150px;
 }
 
 .snacks:hover {

--- a/styles/style.css
+++ b/styles/style.css
@@ -152,7 +152,7 @@ main {
   border-radius: 8px;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s, box-shadow 0.2s;
-  flex: 1 1 150px;
+  flex: 1 1 100px;
 }
 
 .dryck:hover {
@@ -209,7 +209,7 @@ main {
   border: 1px solid #b2dfdb;
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
   transition: transform 0.2s, box-shadow 0.2s;
-  flex: 1 1 150px;
+  flex: 1 1 100px;
 }
 
 .snacks:hover {


### PR DESCRIPTION
### Footer:
 Problem: När sidan skalas ner hamnar texten i footern utanför footern.
- Lösning:
  - Minskat fontstorleken och ökat höjden på footern.
  - Implementerade en flexbox-layout för att säkerställa att texten alltid är centrerad både horisontellt och vertikalt i footern.
  - Justerade min-height i main-sektionen för att synka höjden med footern.


![footer_mediaqueries](https://github.com/user-attachments/assets/0e61639a-36e5-42f4-be0d-aba04796d6d2) ![footer_mediaqueries2](https://github.com/user-attachments/assets/e3a318ca-ee2f-4ab7-a0d4-d149ea0b9341)



### Sections:
**Problem:** Sektionerna var inte responsiva.
- **Lösning**
 Lade till en flexbox-layout för snacks- och drinksektionerna.
   - **Nytt problem:** Rubriken blev inkluderad i wrapen.
   - **Lösning:**
   Lade till width: 100% på rubriken för att den skulle ta upp hela bredden.
      - **Nytt problem:** Fortfarande bara en produkt per rad.
      - **Lösning:**
      La till max-width och flex: 1 1 100px; (Aldrig använt flex-grow-sink-flex innan men de va najjjs).

![product_fix_mediaqueries](https://github.com/user-attachments/assets/6a79496a-44ab-428c-8c31-5affccdb5d9c)![product_fix_mediaqueries2](https://github.com/user-attachments/assets/83b30180-1af4-40c6-8bdc-5d45cef99494)

**Done:**
![product_fix_mediaqueries5](https://github.com/user-attachments/assets/e39a99f2-84c8-4d5b-988c-396280325f2a)

### Merge:
Mergade in origin/main till branchen för att förbereda inför den här PR och det ser nu skevt ut pga nya typsnitt och stiländringar i main. Jag har gjort en ny task och kommer fixa detta, samt fixa all mediaqueries, så typsnitt, bilder osv är mindre på mindre skärm, men väntar tills resterande är klart.